### PR TITLE
Add support for proxy

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -101,6 +101,7 @@ program
   .option('-t, --teamid <value>', 'Team ID')
   .option('-a, --agent-name <value>', 'Agent name')
   .option('-c, --config <value>', 'Configuration file path')
+  .option('-x, --proxy <value>', 'HTTTP/HTTPS Proxy')
   .action((command) => {
     const options = {
       serverUrl: command.serverUrl,
@@ -109,6 +110,7 @@ program
       teamId: command.teamid,
       agentName: command.agentName,
       configPath: command.config,
+      proxy: command.proxy,
     };
     if (process.platform === 'win32') {
       readline

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "katalon-cli",
-  "version": "v1.1.0",
+  "version": "v1.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "katalon-cli",
-  "version": "v1.1.2",
+  "version": "v1.1.3",
   "description": "",
   "main": "cli.js",
   "scripts": {


### PR DESCRIPTION
Users can now specify the proxy for the agent with `-x/--proxy` option when starting the agent with CLI or add config `proxy={HTTP/HTTPS Proxy}` directly to `agentconfig`.