### PR TITLE
Update cancel job mechanic

### DIFF
--- a/src/helper/katalon-request.js
+++ b/src/helper/katalon-request.js
@@ -233,19 +233,6 @@ module.exports = {
     return http.request(config.serverUrl, '/info', options, 'GET');
   },
 
-  getPendingCanceledJobs(token, uuid, teamId) {
-    const options = {
-      auth: {
-        bearer: token,
-      },
-      qs: {
-        uuid,
-        teamId,
-      },
-    };
-    return http.request(config.serverUrl, `${KATALON_JOB_URI}cancel`, options, 'GET');
-  },
-
   updateNodeStatus(token, jobId, nodeStatus) {
     const options = {
       auth: {

--- a/src/service/request-controller.js
+++ b/src/service/request-controller.js
@@ -66,15 +66,6 @@ class KatalonRequestController {
     return makeRequestWithTokenHelper(this.tokenManager.token, katalonRequest.updateJob, body);
   }
 
-  getPendingCanceledJobs(uuid, teamId) {
-    return makeRequestWithTokenHelper(
-      this.tokenManager.token,
-      katalonRequest.getPendingCanceledJobs,
-      uuid,
-      teamId,
-    );
-  }
-
   updateNodeStatus(jobId, nodeStatus) {
     return makeRequestWithTokenHelper(
       this.tokenManager.token,


### PR DESCRIPTION
Instead of getting pending jobs for the cancelation periodically, synchronize job status and cancel directly to avoid killing the reused process id of other programs.