### PR TITLE
Ensure directory exists synchronously

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "katalon-cli",
-  "version": "v1.6.0",
+  "version": "v1.6.1",
   "description": "",
   "main": "cli.js",
   "scripts": {

--- a/src/service/agent.js
+++ b/src/service/agent.js
@@ -138,7 +138,7 @@ async function executeJob(jobInfo, keepFiles) {
 
   // Create directory where temporary files are contained
   const tmpRoot = path.resolve(global.appRoot, 'tmp/');
-  fs.ensureDir(tmpRoot);
+  fs.ensureDirSync(tmpRoot);
 
   // Create temporary directory to keep extracted project
   const tmpDir = utils.createTempDir(tmpRoot, { postfix: jobId });

--- a/src/service/command-executor.js
+++ b/src/service/command-executor.js
@@ -122,7 +122,7 @@ class GenericCommandExecutor {
 
   async execute(logger, execDirPath, callback) {
     const outputDir = path.join(execDirPath, GENERIC_COMMAND_OUTPUT_DIR);
-    fs.ensureDir(outputDir);
+    fs.ensureDirSync(outputDir);
 
     const status = await genericCommand.executeCommands(
       this.commands,


### PR DESCRIPTION
Fix bug when temporary directory is not created due to async call of `ensureDir`.