### PR TITLE
[TOS-5006] Remove update serverUrl

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "katalon-agent",
-  "version": "v1.7.4",
+  "version": "v1.7.5",
   "description": "",
   "main": "cli.js",
   "scripts": {

--- a/src/service/agent.js
+++ b/src/service/agent.js
@@ -306,7 +306,6 @@ class Agent {
           ksArgs = utils.updateCommand(
             parameter.command,
             { flag: '-apiKey', value: this.apikey },
-            { flag: '-serverUrl', value: config.serverUrl },
           );
         }
 
@@ -397,7 +396,6 @@ class Agent {
         ksArgs = utils.updateCommand(
           parameter.command,
           { flag: '-apiKey', value: this.apikey },
-          { flag: '-serverUrl', value: config.serverUrl },
         );
       }
 


### PR DESCRIPTION
* Test with old version by katalon cmd:
![image](https://user-images.githubusercontent.com/69144612/175240158-5e4b03e9-ce34-449d-9165-f471ae1048a3.png)

* Test with  8.4.0 version by katalon cmd:
![image](https://user-images.githubusercontent.com/69144612/175239535-875ff2b8-c90d-404b-a516-adcde7f3be50.png)

Note:
* Because we remove  the serverUrl from updateCommand, TO need to provide serverUrl in the finalCommand. If the TO doesn't provide serverUrl, agent can not run properly with both old and new kre version.