### PR TITLE
[TES-1876] Upgrade Docker Agent to support KRE 8.6.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /katalon
 COPY . .
 
 # Build docker image
-FROM katalonstudio/katalon:8.6.8
+FROM katalonstudio/katalon:8.6.5
 
 # Agent arguement
 ARG AGENT_VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,9 @@ RUN mkdir -p $KATALON_ROOT_DIR
 
 WORKDIR /katalon
 COPY . .
-RUN chmod a+x ./docker/scripts/build_agent.sh
-RUN ./docker/scripts/build_agent.sh
 
 # Build docker image
-FROM katalonstudio/katalon:8.6.5
+FROM katalonstudio/katalon:8.6.8
 
 # Agent arguement
 ARG AGENT_VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,11 @@ RUN mkdir -p $KATALON_ROOT_DIR
 
 WORKDIR /katalon
 COPY . .
+RUN chmod a+x ./docker/scripts/build_agent.sh
+RUN ./docker/scripts/build_agent.sh
 
 # Build docker image
-FROM katalonstudio/katalon:8.6.5
+FROM katalonstudio/katalon:8.6.8
 
 # Agent arguement
 ARG AGENT_VERSION

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "katalon-agent",
-  "version": "v1.7.7",
+  "version": "v1.7.8",
   "description": "",
   "main": "cli.js",
   "scripts": {

--- a/src/core/api/api.js
+++ b/src/core/api/api.js
@@ -98,7 +98,7 @@ module.exports = {
   },
 
   getKSReleases() {
-    return http.get(urlParam.ksReleases());
+    return http.get(urlParam.ksReleases()).catch(() => http.get(urlParam.ksReleasesOldLink()));
   },
 
   download(url, filePath) {

--- a/src/core/api/constants.js
+++ b/src/core/api/constants.js
@@ -36,8 +36,11 @@ const OAUTH2_GRANT_TYPES = {
 
 const FILTERED_ERROR_CODE = new Set([400, 401, 403, 404, 500, 502, 503, 504]);
 
-const KS_RELEASES_URL =
+const KS_OLD_RELEASES_URL =
   'https://raw.githubusercontent.com/katalon-studio/katalon-studio/master/releases.json';
+
+const KS_RELEASES_URL =
+  'https://download.katalon.com/katalon-studio/releases.json';
 
 module.exports = {
   TESTOPS_BASE_URL,
@@ -46,5 +49,6 @@ module.exports = {
   OAUTH2_CLIENT,
   OAUTH2_GRANT_TYPES,
   FILTERED_ERROR_CODE,
+  KS_OLD_RELEASES_URL,
   KS_RELEASES_URL,
 };

--- a/src/core/api/url-param.js
+++ b/src/core/api/url-param.js
@@ -1,4 +1,4 @@
-const { KS_RELEASES_URL, PATHS, REPORT_TYPE } = require('./constants');
+const { KS_RELEASES_URL, PATHS, REPORT_TYPE, KS_OLD_RELEASES_URL } = require('./constants');
 const { buildUrl } = require('./utils');
 
 module.exports = {
@@ -92,6 +92,10 @@ module.exports = {
 
   updateNodeStatus() {
     return buildUrl({}, PATHS.JOB, 'node-status');
+  },
+
+  ksReleasesOldLink() {
+    return buildUrl({ baseUrl: KS_OLD_RELEASES_URL });
   },
 
   ksReleases() {

--- a/test/core/api/url-param.test.js
+++ b/test/core/api/url-param.test.js
@@ -1,0 +1,11 @@
+const { getKSReleases } = require('../../../src/core/api/api');
+
+describe('getKSReleases test', () => {
+  it('Get KS Releases', async () => {
+    /// When
+    const ksReleases = await getKSReleases();
+    const responseStatus = ksReleases.status;
+    /// Then
+    expect(responseStatus).toBe(200);
+  });
+});


### PR DESCRIPTION
## Business flow changes
- When getting releases.json file, get from the link https://download.katalon.com/katalon-studio/releases.json, if fails, get the old link https://raw.githubusercontent.com/katalon-studio/katalon-studio/master/releases.json

## Relate tickets
https://katalon.atlassian.net/browse/TES-4400
