### PR TITLE
[TES-1876] Add wrap_chrome_binary.sh to upgrade_environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ COPY --from=build /katalon/bin/cli-linux-x64 *.sh ./
 
 # Copy script files and setup
 WORKDIR $KATALON_SCRIPT_DIR
-# COPY ./docker/scripts/wrap_chrome_binary.sh wrap_chrome_binary.sh
+COPY ./docker/scripts/wrap_chrome_binary.sh wrap_chrome_binary.sh
 # COPY ./docker/scripts/setup_environment.sh setup_environment.sh
 COPY ./docker/scripts/upgrade_environment.sh upgrade_environment.sh
 COPY ./docker/scripts/setup_agent.sh setup_agent.sh

--- a/docker/scripts/upgrade_environment.sh
+++ b/docker/scripts/upgrade_environment.sh
@@ -7,5 +7,5 @@ chrome_package='google-chrome-stable_current_amd64.deb'
 wget -O $chrome_package  https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
 dpkg -i $chrome_package || apt -y -f install
 rm $chrome_package
-./wrap_chrome_binary.sh && rm -rfv ./wrap_chrome_binary.sh
+./wrap_chrome_binary.sh
 echo "$(google-chrome --version)" >> $KATALON_VERSION_FILE || true

--- a/docker/scripts/upgrade_environment.sh
+++ b/docker/scripts/upgrade_environment.sh
@@ -7,4 +7,5 @@ chrome_package='google-chrome-stable_current_amd64.deb'
 wget -O $chrome_package  https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
 dpkg -i $chrome_package || apt -y -f install
 rm $chrome_package
+./wrap_chrome_binary.sh && rm -rfv ./wrap_chrome_binary.sh
 echo "$(google-chrome --version)" >> $KATALON_VERSION_FILE || true


### PR DESCRIPTION
**Issue**: Able to upgrade Chrome browser but cannot run with Chrome driver
**Root cause:** Chrome needs to run with --no-sandbox on Ubuntu https://stackoverflow.com/questions/53073411/selenium-webdriverexceptionchrome-failed-to-start-crashed-as-google-chrome-is
**Solution**: Allow Chrome to run --no-sandbox
Result:
Here is the log 
[debug.log](https://github.com/katalon-studio/katalon-agent/files/12715655/debug.2.log)