### PR TITLE
[TES-5810] Allow users to define the target directory when creating/updating script repositories

### DIFF
--- a/src/helper/agent.js
+++ b/src/helper/agent.js
@@ -60,9 +60,9 @@ function createCommandExecutor(
   return new KatalonCommandExecutor(info);
 }
 
-function createDownloader(parameter) {
+function createDownloader(parameter, targetDirectory) {
   if (parameter.type === 'GIT') {
-    return new GitDownloader(logger, parameter.gitRepositoryResource);
+    return new GitDownloader(logger, parameter.gitRepositoryResource, targetDirectory);
   }
 
   const downloadUrl = parameter.testOpsDownloadUrl || parameter.downloadUrl;

--- a/src/service/agent.js
+++ b/src/service/agent.js
@@ -109,7 +109,7 @@ function synchronizeJob(jobId, onJobSynchronization = () => {}, apiKey) {
 }
 
 async function executeJob(jobInfo, keepFiles) {
-  const { jobId, projectId, apiKey } = jobInfo;
+  const { jobId, projectId, apiKey, targetDirectory } = jobInfo;
   const notify = () => notifyJob(jobId, projectId, apiKey);
   let isCanceled = false;
   let jLogger;
@@ -140,7 +140,7 @@ async function executeJob(jobInfo, keepFiles) {
 
   // Create temporary directory to keep extracted project
   const tmpDir = utils.createTempDir(tmpRoot, { postfix: jobId });
-  const tmpDirPath = tmpDir.name;
+  let tmpDirPath = tmpDir.name;
   logger.info('Download test project to temp directory:', tmpDirPath);
 
   // Create job logger
@@ -188,6 +188,9 @@ async function executeJob(jobInfo, keepFiles) {
 
     logger.info(`Create controller for job ID: ${jobId}`);
     let processId = null;
+    if (targetDirectory && targetDirectory !== '') {
+      tmpDirPath += `/${targetDirectory}`;
+    }
     const status = await executor.execute(jLogger, tmpDirPath, (pid) => {
       processId = pid;
       processController.createController(pid, jobId);
@@ -298,7 +301,7 @@ class Agent {
         const {
           id: jobId,
           parameter,
-          testProject: { projectId },
+          testProject: { projectId, targetDirectory },
         } = jobBody;
 
         let ksArgs;
@@ -329,6 +332,7 @@ class Agent {
           jobId,
           projectId,
           apiKey,
+          targetDirectory,
         };
 
         await executeJob(jobInfo, keepFiles);

--- a/src/service/agent.js
+++ b/src/service/agent.js
@@ -109,7 +109,7 @@ function synchronizeJob(jobId, onJobSynchronization = () => {}, apiKey) {
 }
 
 async function executeJob(jobInfo, keepFiles) {
-  const { jobId, projectId, apiKey, targetDirectory } = jobInfo;
+  const { jobId, projectId, apiKey } = jobInfo;
   const notify = () => notifyJob(jobId, projectId, apiKey);
   let isCanceled = false;
   let jLogger;
@@ -140,7 +140,7 @@ async function executeJob(jobInfo, keepFiles) {
 
   // Create temporary directory to keep extracted project
   const tmpDir = utils.createTempDir(tmpRoot, { postfix: jobId });
-  let tmpDirPath = tmpDir.name;
+  const tmpDirPath = tmpDir.name;
   logger.info('Download test project to temp directory:', tmpDirPath);
 
   // Create job logger
@@ -188,9 +188,6 @@ async function executeJob(jobInfo, keepFiles) {
 
     logger.info(`Create controller for job ID: ${jobId}`);
     let processId = null;
-    if (targetDirectory && targetDirectory !== '') {
-      tmpDirPath += `/${targetDirectory}`;
-    }
     const status = await executor.execute(jLogger, tmpDirPath, (pid) => {
       processId = pid;
       processController.createController(pid, jobId);
@@ -317,7 +314,7 @@ class Agent {
           );
         }
 
-        const downloader = createDownloader(parameter);
+        const downloader = createDownloader(parameter, targetDirectory);
         const executor = createCommandExecutor(
           projectId,
           ksArgs,
@@ -332,7 +329,6 @@ class Agent {
           jobId,
           projectId,
           apiKey,
-          targetDirectory,
         };
 
         await executeJob(jobInfo, keepFiles);

--- a/src/service/remote-downloader.js
+++ b/src/service/remote-downloader.js
@@ -23,14 +23,15 @@ class KatalonTestProjectDownloader {
 }
 
 class GitDownloader {
-  constructor(logger, gitRepository, cloneOpts = {}) {
+  constructor(logger, gitRepository, targetDirectory, cloneOpts = {}) {
     this.logger = logger;
     this.gitRepository = gitRepository;
     this.cloneOpts = cloneOpts;
+    this.targetDirectory = targetDirectory;
   }
 
-  download(targetDir) {
-    return file.clone(this.gitRepository, targetDir, this.cloneOpts, this.logger);
+  download(downloadDir) {
+    return file.clone(this.gitRepository, this.targetDirectory, downloadDir, this.cloneOpts, this.logger);
   }
 }
 


### PR DESCRIPTION
## TICKET 
https://katalon.atlassian.net/browse/TES-5816
## SUMMARY
- Support feature Allow users to define the target directory when creating/updating script repositories
- Change variable named targetDir to downloadDir - this is the temp directory to clone Git repo. To prevent namesake with targetDirectory defined
## RELATIVE PRS
- https://github.com/katalon-studio/katalon-testops-private/pull/13223
- https://github.com/katalon-studio/test-management/pull/315