### PR TITLE
fix(CO-4739): replace GH_TOKEN with GH_TOKEN_READ_PACKAGE in publish_agent workflow

### DIFF
--- a/.github/workflows/publish_agent.yml
+++ b/.github/workflows/publish_agent.yml
@@ -300,7 +300,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-            token: ${{ secrets.GH_TOKEN }}
+            token: ${{ secrets.GH_TOKEN_READ_PACKAGE }}
 
       - name: Set BUILD_VERSION environment variable
         run: echo "BUILD_VERSION=$(node -p "require('./package').version")" >> $GITHUB_ENV


### PR DESCRIPTION
## What
Replace `GH_TOKEN` with org-level secret `GH_TOKEN_READ_PACKAGE` in the checkout step of the `commit` job.

## Why
Migrating from PATs to more secure token usage as part of the org-wide CI/CD authentication improvement.

## Changes
- `.github/workflows/publish_agent.yml`

## Jira
[CO-4739](https://katalon.atlassian.net/browse/CO-4739)

[CO-4739]: https://katalon.atlassian.net/browse/CO-4739?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Replaced GH_TOKEN with GH_TOKEN_READ_PACKAGE in publish_agent workflow checkout step


<sup>[More info](https://app.aikido.dev/featurebranch/scan/113559028?groupId=17424)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->