### PR TITLE
deps(security): axios 1.10.0 -> 1.16.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "katalon-agent",
-  "version": "v2.5.1",
+  "version": "v2.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "katalon-agent",
-      "version": "v2.5.1",
+      "version": "v2.6.0",
       "license": "ISC",
       "dependencies": {
-        "axios": "^1.6.8",
+        "axios": "^1.16.1",
         "axios-cached-dns-resolve": "^3.3.0",
         "commander": "^7.0.0",
         "compare-versions": "^6.1.0",
@@ -2429,13 +2429,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.10.0.tgz",
-      "integrity": "sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/axios-cached-dns-resolve": {
@@ -2450,6 +2451,37 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/axios/node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/babel-jest": {
@@ -4762,9 +4794,9 @@
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -4795,9 +4827,9 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
-      "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -8328,7 +8360,8 @@
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true
     },
     "node_modules/pump": {
       "version": "3.0.3",
@@ -9993,6 +10026,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test": "jest --passWithNoTests"
   },
   "dependencies": {
-    "axios": "^1.6.8",
+    "axios": "^1.16.1",
     "axios-cached-dns-resolve": "^3.3.0",
     "commander": "^7.0.0",
     "compare-versions": "^6.1.0",


### PR DESCRIPTION
## Security issue addressed

- Source: Aikido open-source findings for `katalon-studio/katalon-agent`: CVE-2026-42043, CVE-2025-62718, CVE-2026-42264, CVE-2026-42044, CVE-2026-40175, CVE-2026-42038, CVE-2026-42039, AIKIDO-2026-10823, CVE-2026-25639, CVE-2025-58754, CVE-2026-42033, CVE-2026-42035, CVE-2026-42041, CVE-2026-42042, AIKIDO-2026-10820, CVE-2026-42037, CVE-2026-42036, CVE-2026-42034, AIKIDO-2026-10509, CVE-2026-42040, AIKIDO-2026-10822, AIKIDO-2026-10819
- Type: dependency
- Severity: critical
- Affected component: `axios` in `package.json` / `package-lock.json`
- Summary: Aikido reports multiple vulnerable `axios` findings for the locked `1.10.0` version. This PR updates the direct `axios` dependency and lockfile to `1.16.1`, the remediation target covering the current Aikido axios findings.

## Tracking ticket

- KVDP/Jira: [KVDP-9005](https://katalon.atlassian.net/browse/KVDP-9005)
- Ticket status: existing
- Owner/queue: Unassigned

## What changed

- Updated `package.json` direct dependency `axios` from `^1.6.8` to `^1.16.1`.
- Updated `package-lock.json` to resolve `axios` from `1.10.0` to `1.16.1`.
- Refreshed axios transitive lockfile entries, including `follow-redirects`, `form-data`, `https-proxy-agent`, and `proxy-from-env` resolution changes required by `axios@1.16.1`.

## Expected impact

- Security impact: Removes the vulnerable locked `axios@1.10.0` version identified by Aikido and resolves to the patched `1.16.1` target.
- Functional impact: No user-facing behavior expected; axios remains on the same major version.
- Operational impact: None expected.

## Verification evidence

- Tests run: `mise exec node@20.9.0 -- npm ci` — pass; install completed from the refreshed lockfile.
- Tests run: `mise exec node@20.9.0 -- npm run eslint` — pass with existing warnings only (`0 errors, 10 warnings`).
- Tests run: `mise exec node@20.9.0 -- npm run test:coverage` — fail; existing Jest failures in `test/service/command-executor.test.js` plus timeout. The CI workflow currently runs this command with `|| true`.
- Tests run: `mise exec node@20.9.0 -- npm run build` — pass; esbuild produced `agent-bundle.js` successfully.
- Tests run: `mise exec node@20.9.0 -- npm ls axios --depth=0` — pass; reports `axios@1.16.1`.
- Security validation: `mise exec node@20.9.0 -- npm audit --omit=dev --json` — no `axios` entry in remaining production audit vulnerabilities; unrelated vulnerabilities remain in other packages.
- Compatibility check: CI and local runtime inspected as Node.js `20.9.0` via `.nvmrc`, GitHub Actions matrices, and Dockerfile; local verification used `mise exec node@20.9.0`.

## Rollout and compatibility risk

- Risk level: low
- Compatibility notes: Same-major axios upgrade. Lockfile changes include axios transitive dependency updates expected for the patched release.
- Rollback plan: Revert this PR.

## Ownership and review notes

- Suggested reviewers/owners: Repo owners
- Follow-ups: KVDP-9005 tracks this remediation. Remaining non-axios dependency findings should be handled separately.
- Human decision required: Engineering review/approval is required before merge.


[KVDP-9005]: https://katalon.atlassian.net/browse/KVDP-9005?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 | ✅ Resolved Issues: 19 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Updated axios dependency from ^1.6.8 to ^1.16.1 in package.json


<sup>[More info](https://app.aikido.dev/featurebranch/scan/123099764?groupId=17424)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->